### PR TITLE
Add the 'master-worker' global option.

### DIFF
--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -6,6 +6,7 @@ global
     user haproxy
     group haproxy
     stats socket /run/haproxy.sock user haproxy group haproxy mode 660 level admin
+    master-worker
 
 defaults
     mode http


### PR DESCRIPTION
This PR adds the `master-worker` global option required for the HAProxy Data Plane API to work as expected:

```
PUT /v1/services/haproxy/transactions/885a9201-9845-47c5-905b-46f8486a7441?force_reload=false HTTP/1.1
Host: localhost:5555
User-Agent: Go-http-client/1.1
Content-Length: 0
Accept: application/json
Authorization: Basic (redacted)
Content-Type: application/json
Accept-Encoding: gzip


HTTP/1.1 400 Bad Request
Content-Length: 152
Configuration-Version: 0
Content-Type: application/json
Date: Thu, 23 Jan 2020 14:25:44 GMT
Vary: Origin

{"code":400,"message":"14: ERR transactionId=885a9201-9845-47c5-905b-46f8486a7441 \nmsg=\"Can't use a 'program' section without master worker mode.\""}
```